### PR TITLE
db migrations fix for start from scratch

### DIFF
--- a/supabase/migrations/20250125094934_common.sql
+++ b/supabase/migrations/20250125094934_common.sql
@@ -1,6 +1,6 @@
 -- region Slugify Function
 create extension unaccent schema public;
-drop function public.slugify(value text);
+drop function if exists public.slugify(value text);
 create function public.slugify(value text) returns text
     language plpgsql
     immutable strict set search_path to '' as


### PR DESCRIPTION
Hi, was setting up colibri locally, and 
pnpx supabase start failed, complaining about public.slugify not existing.

I've changed
db migrations - added 'if exists' to drop of public.slugify, so it works when starting from scratch

Cheers